### PR TITLE
Add app.iml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ captures/
 .idea/gradle.xml
 .idea/dictionaries
 .idea/libraries
+/app/app.iml
 
 # Keystore files
 *.jks
@@ -53,3 +54,4 @@ google-services.json
 freeline.py
 freeline/
 freeline_project_description.json
+

--- a/README.md
+++ b/README.md
@@ -7,4 +7,10 @@
 - Andrew
 - Steve
 - kvlinden
-- Joseph Jinn
+- Joseph Jinn  
+
+___________
+
+To generate the app.iml file:
+1. Rename `app.iml.template` to `app.iml` in under the `app` directory
+1. Hit the button "Sync Project with Gradle Files" (The green circle with blue arrows going around it on the toolbar, next to the VCS pull button)

--- a/app/app.iml.template
+++ b/app/app.iml.template
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id=":app" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+</module>


### PR DESCRIPTION
We can now remove the app.iml file from the index with `git rm --cached app/app.iml` and not need to track the auto-generated file